### PR TITLE
Allow /etc/ng-rddmarc/ng-rddmarc.conf as alternative config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Options:
              move completed to cur/ dir.
     -c       if path is Maildir, also process cur/ on startup
 
-  The following 'conf:' lines can be stored in $HOME/.ng-rddmarc.conf.
+  The following 'conf:' lines can be stored in $HOME/.ng-rddmarc.conf or
+  /etc/ng-rddmarc/ng-rddmarc.conf.
     -U xxx   database user        conf: $opt_U = "username";
     -P xxx   database password    conf: $opt_P = "password";
     -N xxx   database name        conf: $opt_N = "dbname";
@@ -75,7 +76,8 @@ Options:
 
 # Configuration
 See the <code>contrib/dot&#x5f;ng-rddmarc.conf</code> file for example
-config. Place it in <code>$HOME/.ng-rddmarc.conf</code> to configure
+config. Place it in <code>$HOME/.ng-rddmarc.conf</code> or
+<code>/etc/ng-rddmarc/ng-rddmarc.conf</code> to configure
 the database connection. Configuration options specified via command
 line override those specified in the configuration file.<br/>
 A valid database environment is needed for operation.

--- a/ng-rddmarc
+++ b/ng-rddmarc
@@ -10,7 +10,12 @@ use Filesys::Notify::Simple;
 use Data::Dumper; $Data::Dumper::Sortkeys = 1;
 use Socket qw(:addrinfo inet_ntop inet_pton AF_INET6 AF_INET);
 use Getopt::Std; $main::VERSION = '0.999beta5'; $Getopt::Std::STANDARD_HELP_VERSION = 1;
+
 my $conffile = $ENV{HOME} . '/.ng-rddmarc.conf';
+if (! -f ($conffile))
+{
+	$conffile = "/etc/ng-rddmarc/ng-rddmarc.conf";
+}
 
 
 use vars qw($opt_h $opt_s $opt_d $opt_r $opt_w $opt_n $opt_m $opt_c


### PR DESCRIPTION
/etc/ is a common place for config files so it should be also possible to place the config file there